### PR TITLE
intentionally not adding objects whose id field is null

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -80,14 +80,17 @@ function injectResultInCollection(result, mappedCollection, maps, mapId, columnP
     let idProperty = getIdProperty(resultMap);
     let mappedObject = _.find(mappedCollection, idProperty.name, result[columnPrefix + idProperty.column]);
 
-    // Create mappedObject if it does not exist in mappedCollection
-    if (!mappedObject) {
-        mappedObject = createMappedObject(resultMap);
-        mappedCollection.push(mappedObject);
-    }
+    // ignore null keys
+    if ( result[columnPrefix + idProperty.column]) {
+        // Create mappedObject if it does not exist in mappedCollection
+        if (!mappedObject) {
+            mappedObject = createMappedObject(resultMap);
+            mappedCollection.push(mappedObject);
+        }
 
-    // Inject result in object
-    injectResultInObject(result, mappedObject, maps, mapId, columnPrefix);
+        // Inject result in object
+        injectResultInObject(result, mappedObject, maps, mapId, columnPrefix);
+    }
 }
 
 /**


### PR DESCRIPTION
complex joins may produce objects will all null properties, this
removes those, but will still show an empty array if it was part of a
collection