### PR TITLE
Include NotFoundError in type definition file

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -18,9 +18,11 @@ declare module "join-js" {
       columnPrefix?: string;
     }[];
   };
+  declare function NotFoundError(message?: string): void;
   const JoinJs: {
     map(resultSet: any[], maps: ResultMap[], mapId: string, columnPrefix?: string): any;
     mapOne(resultSet: any[], maps: ResultMap[], mapId: string, columnPrefix?: string, isRequired?: boolean): any;
+    NotFoundError: NotFoundError
   };
   export default JoinJs;
 }


### PR DESCRIPTION
The `NotFoundError` that is currently exported in the source file, but not from the type definition file